### PR TITLE
strip the read-in version number of extra whitespace

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'projects@gridtec.at'
 license 'Apache 2.0'
 description 'Installs/Configures Pyload'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version IO.read(File.join(File.dirname(__FILE__), 'VERSION'))
+version IO.read(File.join(File.dirname(__FILE__), 'VERSION')).chomp
 
 %w(debian ubuntu centos redhat fedora suse opensuse arch freebsd).each do |os|
   supports os


### PR DESCRIPTION
Just in case the VERSION file gets a newline added back in by an enthusiastic text editor.

```
> IO.read(File.join(File.dirname(__FILE__), 'VERSION'))
=> "1.2.0\n"
> IO.read(File.join(File.dirname(__FILE__), 'VERSION')).chomp
=> "1.2.0"
```